### PR TITLE
use python3 on shebang line

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # pyproj documentation build configuration file, created by


### PR DESCRIPTION
use of plain python may suggest python2 is still supported and generates an error when I apply pylint-3 on the rpm package that is generated for Fedora.